### PR TITLE
Add ICS event calendar producer / digest calendar event invitations ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This repository contains both digest as well as scripts for sending emails to co
 In order to send email, you have to perform three magic steps:
 
 ## 1. Build HTML from Markdown
-
 ```
 groovy <parameters>  markdown2html.groovy > body.html
 ```
@@ -14,7 +13,6 @@ groovy <parameters>  markdown2html.groovy > body.html
 `-Dtemplate` - relative path to markdown template
 
 ## 2. Collect and store recipients in a file
-
 ```
 groovy <parameters> collect_recipients.groovy > recipients.txt
 ```
@@ -26,15 +24,48 @@ groovy <parameters> collect_recipients.groovy > recipients.txt
 
 ### Optional parameters
 `-Dskip.event` - if specified, does not collect members of the given event 
- 
 
-## 3. Send email to recipients
+## 3. (Optional) Create monthly event iCalendar
+```
+groovy <parameters> calendar.groovy
+```
+
+### Required parameters
+`-Dout` - iCalendar output file name
+ 
+`-Dname` - Event name
+ 
+`-Dlocation` - Event location
+ 
+`-Ddescription` - Event description
+ 
+`-DdateTime` - DateTime in `d/M/yyyy H:m` format
+
+### Examples
+```shell
+groovy -Dout=latcraftonair.ics \
+  -Dname="Latcraft On Air" \
+  -Dlocation="https://www.youtube.com/channel/UCvzMZyJZZ3XYQwbvOACVYrQ" \
+  -Ddescription="Talk with Java gods" \
+  -DdateTime='17/05/2015 10:00' \
+  calendar.groovy
+```
+
+```shell
+groovy -Dout=pub.ics \
+  -Dname="Pub" \
+  -Dlocation="Beļgu alus" \
+  -Ddescription="Pub meet" \
+  -DdateTime='17/05/2015 10:00' \
+  calendar.groovy                                  
+```
+
+## 4. Send email to recipients
 ```
 groovy <parameters> sender.groovy < recipients.txt
 ```
 
 ### Required parameters
-
 `-Dsendgrid.user` - SendGrid username
 
 `-Dsendgrid.password` - SendGrid password
@@ -44,6 +75,9 @@ groovy <parameters> sender.groovy < recipients.txt
 `-Demail.from` - sender email (normally `hello@latcraft.lv`)
 
 `-Demail.subject` - email subject
+
+### Optional parameters
+`-Dcalendar` - iCalendar (`*.ics`) file to be sent out as event invitation. 
 
 # Misc
 Access credentials can be obtained [here](https://github.com/latcraft/passwords).

--- a/calendar.groovy
+++ b/calendar.groovy
@@ -1,0 +1,66 @@
+@Grab(group = 'org.mnode.ical4j', module = 'ical4j', version = '1.0.6')
+import net.fortuna.ical4j.util.*
+import net.fortuna.ical4j.data.*
+import net.fortuna.ical4j.model.*
+import net.fortuna.ical4j.model.property.*
+import net.fortuna.ical4j.model.parameter.*
+import net.fortuna.ical4j.model.component.*
+
+import static java.util.Objects.requireNonNull
+
+def arg(name, desc) {
+    def value = System.getProperty(name)
+    requireNonNull(value, "Please specify -D${name} arg - ${desc}")
+}
+
+eventName = arg("name", "Event name")
+eventLocation = arg("location", "Event location")
+eventDescription = arg("description", "Event description")
+eventDateTime = arg("dateTime", "DateTime in `d/M/yyyy H:m` format")
+
+outfile = arg("out", "iCalendar output file name")
+
+// Obtains local timezone object (in our case Europe/Riga)
+TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry()
+TimeZone timezone = registry.getTimeZone("Europe/Riga")
+
+// Calculates event start/end datetime (from command line arguments)
+java.util.Calendar startDate = new GregorianCalendar()
+startDate.setTime(new Date().parse("d/M/yyyy H:m", eventDateTime, timezone))
+java.util.Calendar endDate = new GregorianCalendar()
+endDate.setTime(startDate.getTime())
+endDate.add(java.util.Calendar.MINUTE, 30)
+
+// Create the event
+DateTime start = new DateTime(startDate.getTime())
+DateTime end = new DateTime(endDate.getTime())
+VEvent meeting = new VEvent(start, end, eventName)
+// Add timezone info
+VTimeZone tz = timezone.getVTimeZone()
+meeting.getProperties().add(tz.getTimeZoneId())
+// Add unique identifier
+UidGenerator ug = new UidGenerator("latcraft")
+meeting.getProperties().add(ug.generateUid())
+// Add event location details
+meeting.getProperties().add(new Location(eventLocation))
+try{ def uri = new URL(eventLocation).toURI(); meeting.getProperties().add(new Url(uri)); }catch(MalformedURLException ignore){}
+// Add description
+meeting.getProperties().add(new Description(eventDescription))
+// Add event organizer details
+ParameterList pl = new ParameterList();
+pl.add(new Cn("Latvian Software Craftsmanship Community"))      // Visible name of organizer
+pl.add(new SentBy("calendar@latcraft.lv"))                      // Not important
+def orgEmail = URI.create("mailto:calendar@latcraft.lv")        // Will be used in replies and accept/reject mail notifications
+meeting.getProperties().add(new Organizer(pl, orgEmail))
+
+// Create a calendar with events...
+net.fortuna.ical4j.model.Calendar calendar = new net.fortuna.ical4j.model.Calendar()
+calendar.getProperties().add(new ProdId("-//Events Calendar//iCal4j 1.0//EN"))
+calendar.getProperties().add(Version.VERSION_2_0)
+calendar.getProperties().add(CalScale.GREGORIAN)
+calendar.getComponents().add(meeting)
+
+// Validate & printout to file
+calendar.validate()
+CalendarOutputter outputter = new CalendarOutputter()
+outputter.output(calendar, new FileOutputStream(outfile))

--- a/sender.groovy
+++ b/sender.groovy
@@ -1,13 +1,10 @@
 @Grab('com.sendgrid:sendgrid-java:2.0.0')
 import com.sendgrid.*
 
-@Grab('com.netflix.rxjava:rxjava-groovy:0.14.0')
-import rx.Observable
+import static java.util.Objects.requireNonNull
 
-import static java.util.Objects.*
-
-def arg(name) {
-	def value = System.getProperty(name)
+def arg(String name, String defaultValue = null) {
+	def value = System.getProperty(name, defaultValue)
 	requireNonNull(value, "Please specify -D$name arg")
 }
 
@@ -18,22 +15,25 @@ email_from = arg "email.from"
 email_subject = arg "email.subject"
 email_body = arg "email.body"
 
+calendar_events = [arg("calendar", "")].findAll({ !it.isEmpty() }).collect({ new File(it) })
+
 def sendgrid = new SendGrid(sendgrid_user, sendgrid_password)
 
-System.in.eachLine() { emailTo ->  
+System.in.eachLine() { emailTo ->
 	def email = new SendGrid.Email(
-		to: [ emailTo ], 
+		to: [ emailTo ],
 		from: email_from,
 		fromName: "Latvian Software Craftsmanship Community",
 		subject: email_subject,
 		html: new File(email_body).text,
-		replyTo: "no-reply@latcraft.lv"
+		replyTo: "no-reply@latcraft.lv",
+		attachments: calendar_events.collectEntries { [it.name, new FileInputStream(it)] }
 	)
 
 	def response = sendgrid.send(email)
 	println "Sending email to $emailTo -> $response.code / $response.message"
 
-} 
+}
 
 
 
@@ -41,7 +41,7 @@ System.in.eachLine() { emailTo ->
 
 
 
- 
+
 
 
 


### PR DESCRIPTION
- At the moment there is POC (proof of concept) calendar event producer, `calendar.groovy`
  I use it locally as follows:
  
  ``` shell
  $ groovy -DdateTime='17/05/2015 10:00' -Dout=latcraftonair.ics calendar.groovy
  ```
- I've added (temporarily, as POC) latcraftonair.ics sending out as attachment (`sender.groovy` script)

---

As long as I don't really know what type of events and how many could be sent out in the digest (other than latcarftonair), I've added only it and didn't bother too much too streamline multiple events production & passing in as arguments to `sender.groovy`

Please take a look. What do you think and how should I adjust it before you can take it? 
Kudos!
